### PR TITLE
fix: canonicalize project roots via portableResolve so Windows CI stops diverging

### DIFF
--- a/plugins/filid/src/core/infra/cacheManager/caches/cwdHash.ts
+++ b/plugins/filid/src/core/infra/cacheManager/caches/cwdHash.ts
@@ -1,5 +1,18 @@
 import { createHash } from 'node:crypto';
 
+import { portableResolve } from '@ogham/cross-platform/paths';
+
+/**
+ * Project key for a workspace. The path is canonicalised through the portable
+ * resolver first — never native `path.resolve` — so a raw cwd and its resolved
+ * form hash to one cache directory whatever spelling a call site passed and
+ * whatever OS the server runs on. Boot-sweep resolves through the same portable
+ * path, so writer and sweeper always agree; a host-dependent resolve made them
+ * diverge on Windows and left expired sessions unswept.
+ */
 export function cwdHash(cwd: string): string {
-  return createHash('sha256').update(cwd).digest('hex').slice(0, 16);
+  return createHash('sha256')
+    .update(portableResolve(cwd))
+    .digest('hex')
+    .slice(0, 16);
 }

--- a/plugins/maencof/src/__tests__/unit/vaultRedirector.test.ts
+++ b/plugins/maencof/src/__tests__/unit/vaultRedirector.test.ts
@@ -272,3 +272,23 @@ describe('isVaultDocDirectory', () => {
     expect(isVaultDocDirectory(cwd, '../outside')).toBe(false);
   });
 });
+
+// isVaultInternalPath/isVaultDocDirectory 는 순수 함수라 실행 OS 와 무관하게
+// Windows-flavored(드라이브 레터) 입력으로 검증할 수 있다. 네이티브 path 를
+// 쓰면 러너 OS 에 따라 결과가 갈라졌고, 대소문자 구분 비교는 Windows(대소문자
+// 무시 FS)에서 내부 관리 디렉토리를 놓쳐 잘못된 리다이렉트 힌트를 냈다.
+describe('Windows-flavored 경로 (대소문자 무시 FS)', () => {
+  const winCwd = 'C:\\vault';
+
+  it('내부 디렉토리는 대소문자가 달라도 제외한다', () => {
+    expect(isVaultInternalPath(winCwd, '.Maencof-Meta/notes.md')).toBe(false);
+    expect(isVaultInternalPath(winCwd, '.MAENCOF/notes.md')).toBe(false);
+    expect(isVaultDocDirectory(winCwd, '.Maencof-Meta')).toBe(false);
+    expect(isVaultDocDirectory(winCwd, '.MAENCOF/subdir')).toBe(false);
+  });
+
+  it('내부 디렉토리가 아닌 vault 문서는 그대로 인식한다', () => {
+    expect(isVaultInternalPath(winCwd, '01_Core/values.md')).toBe(true);
+    expect(isVaultDocDirectory(winCwd, '01_Core')).toBe(true);
+  });
+});

--- a/plugins/maencof/src/hooks/preToolUse/helpers/vaultRedirector/operations/isVaultDocDirectory.ts
+++ b/plugins/maencof/src/hooks/preToolUse/helpers/vaultRedirector/operations/isVaultDocDirectory.ts
@@ -2,29 +2,42 @@
  * @file isVaultDocDirectory.ts
  * @description vault 루트 또는 문서 디렉토리인지 판별한다 (내부 관리 디렉토리 제외).
  */
-import { isAbsolute, relative, resolve } from 'node:path';
+import { isAbsolute } from 'node:path';
 
-import { normalize } from '@ogham/cross-platform/paths';
+import {
+  normalize,
+  pathForCompare,
+  portableRelative,
+  portableResolve,
+} from '@ogham/cross-platform/paths';
 
 import { INTERNAL_DIRS } from './internalDirs.js';
 
 /**
  * vault 루트 또는 문서 디렉토리인지 판별한다 (내부 관리 디렉토리 제외).
  * Glob의 path (검색 디렉토리) 검사에 사용된다.
+ *
+ * 경로 연산은 portable* 로 처리해 실행 OS 와 무관하게 결정적이며, 내부 관리
+ * 디렉토리 제외는 절대경로를 `pathForCompare` 로 비교해 Windows 에서 대소문자
+ * 차이가 있어도 매칭된다.
  */
 export function isVaultDocDirectory(cwd: string, dirPath: string): boolean {
-  const resolvedCwd = resolve(cwd);
-  const absPath = resolve(resolvedCwd, dirPath);
-  const relPath = normalize(relative(resolvedCwd, absPath));
+  const resolvedCwd = portableResolve(cwd);
+  const absPath = portableResolve(resolvedCwd, dirPath);
+  const relPath = normalize(portableRelative(resolvedCwd, absPath));
 
   // vault 루트이거나 하위 디렉토리여야 함
   if (relPath === '..' || relPath.startsWith('../') || isAbsolute(relPath))
     return false;
 
   // 내부 관리 디렉토리 제외
-  if (relPath !== '')
-    for (const dir of INTERNAL_DIRS)
-      if (relPath.startsWith(dir + '/') || relPath === dir) return false;
+  if (relPath !== '') {
+    const absKey = pathForCompare(absPath);
+    for (const dir of INTERNAL_DIRS) {
+      const dirKey = pathForCompare(portableResolve(resolvedCwd, dir));
+      if (absKey === dirKey || absKey.startsWith(dirKey + '/')) return false;
+    }
+  }
 
   return true;
 }

--- a/plugins/maencof/src/hooks/preToolUse/helpers/vaultRedirector/operations/isVaultInternalPath.ts
+++ b/plugins/maencof/src/hooks/preToolUse/helpers/vaultRedirector/operations/isVaultInternalPath.ts
@@ -2,19 +2,29 @@
  * @file isVaultInternalPath.ts
  * @description vault 내부 마크다운 파일인지 판별한다.
  */
-import { isAbsolute, relative, resolve } from 'node:path';
+import { isAbsolute } from 'node:path';
 
-import { normalize } from '@ogham/cross-platform/paths';
+import {
+  normalize,
+  pathForCompare,
+  portableRelative,
+  portableResolve,
+} from '@ogham/cross-platform/paths';
 
 import { INTERNAL_DIRS } from './internalDirs.js';
 
 /**
  * vault 내부 마크다운 파일인지 판별한다.
+ *
+ * 경로 연산은 네이티브 `path` 가 아니라 portable* 로 처리해 실행 OS 와 무관하게
+ * 결정적이다. 내부 관리 디렉토리(.maencof / .maencof-meta) 제외는 절대경로를
+ * `pathForCompare` 로 비교한다 — Windows(대소문자 무시 FS)에서 `.Maencof-Meta`
+ * 같은 표기가 같은 디렉토리를 가리켜도 매칭되도록.
  */
 export function isVaultInternalPath(cwd: string, filePath: string): boolean {
-  const resolvedCwd = resolve(cwd);
-  const absPath = resolve(resolvedCwd, filePath);
-  const relPath = normalize(relative(resolvedCwd, absPath));
+  const resolvedCwd = portableResolve(cwd);
+  const absPath = portableResolve(resolvedCwd, filePath);
+  const relPath = normalize(portableRelative(resolvedCwd, absPath));
 
   if (
     relPath === '' ||
@@ -24,8 +34,11 @@ export function isVaultInternalPath(cwd: string, filePath: string): boolean {
   )
     return false;
 
-  for (const dir of INTERNAL_DIRS)
-    if (relPath.startsWith(dir + '/') || relPath === dir) return false;
+  const absKey = pathForCompare(absPath);
+  for (const dir of INTERNAL_DIRS) {
+    const dirKey = pathForCompare(portableResolve(resolvedCwd, dir));
+    if (absKey === dirKey || absKey.startsWith(dirKey + '/')) return false;
+  }
 
   if (!absPath.endsWith('.md')) return false;
 

--- a/shared/cross-platform/src/hostPaths/INTENT.md
+++ b/shared/cross-platform/src/hostPaths/INTENT.md
@@ -12,14 +12,14 @@
 | `pluginRoot.ts`      | 자기 설치 디렉터리 (번들 자산·계약 스크립트·설정 HTML)             |
 | `projectRoot.ts`     | 사용자 작업물 루트 — `projectRoot`(throw) / `tryProjectRoot`(null) |
 | `projectRootMemo.ts` | 프로세스당 workspace 좌표 기억 (claude 에서는 무시)                |
-| `absoluteRoot.ts`    | 공급된 경로의 절대성 강제 + 정규화                                 |
+| `absoluteRoot.ts`    | 공급된 경로의 절대성 강제 + `portableResolve` 정규화 (호스트 독립) |
 
 ## Conventions
 
 - `pluginRoot()` 는 **env 우선** — Codex 는 훅 프로세스에 `CLAUDE_PLUGIN_ROOT` 를 주입하고 그 cwd 는 세션 디렉터리다. env 부재 + codex 일 때만 cwd 로 폴백한다.
 - `projectRoot()` 의 claude 분기는 `process.cwd()` — 기존 동작과 완전히 동일해야 한다 (가산적 변경).
 - claude 외 호스트에서 해석 실패는 **throw** — `process.cwd()` 폴백은 플러그인 폴더를 프로젝트로 오인하는 바로 그 결함이다.
-- 공급된 경로는 **절대경로만** 수용하고 `resolve()` 로 정규화한다 — 상대경로는 (호스트 무관) 플러그인 폴더 기준으로 풀리고, 소비처가 `sha256(root)` 로 프로젝트를 식별하므로 표기 차이가 프로젝트를 갈라놓는다.
+- 공급된 경로는 **절대경로만** 수용하고 `portableResolve` 로 정규화한다 (네이티브 `resolve` 금지) — 소비처가 `sha256(root)` 로 프로젝트를 식별하는데, 네이티브 `resolve` 는 Windows 에서만 구분자·드라이브를 바꿔 같은 작업물을 러너마다 다른 프로젝트로 가른다. `portableResolve` 는 경로 플레이버로 win32/posix 를 정해 호스트와 무관하게 결정적이다.
 
 ## Boundaries
 
@@ -40,4 +40,5 @@
 
 ## Dependencies
 
-- 외부: Node 내장 (`node:path`) 만.
+- 외부: Node 내장 (`node:path`).
+- 내부: `../paths` (`portableResolve` — 정규화 단일 경유).

--- a/shared/cross-platform/src/hostPaths/absoluteRoot.ts
+++ b/shared/cross-platform/src/hostPaths/absoluteRoot.ts
@@ -1,4 +1,6 @@
-import { isAbsolute, resolve } from "node:path";
+import { isAbsolute } from "node:path";
+
+import { portableResolve } from "../paths/index.js";
 
 /**
  * A supplied workspace path must be absolute. A relative one would resolve against
@@ -6,12 +8,15 @@ import { isAbsolute, resolve } from "node:path";
  * exact confusion this module exists to remove, so it is rejected rather than
  * quietly resolved.
  *
- * The absolute form is canonicalised because consumers hash it (`sha256(root)` is
- * the project identity in deilen and cennad); two spellings of the same directory
- * must not produce two projects.
+ * Canonicalisation goes through `portableResolve`, never native `path.resolve`: a
+ * POSIX-style path keeps POSIX semantics and a Windows path keeps Windows semantics
+ * whatever OS the server runs on. Consumers hash the result (`sha256(root)` is the
+ * project identity in deilen, cennad and filid), and host-dependent `resolve()`
+ * rewrote separators and prepended a drive on Windows only — so the same workspace
+ * split into two projects across runners.
  */
 export function toAbsoluteRoot(value: string): string | null {
-  return isAbsolute(value) ? resolve(value) : null;
+  return isAbsolute(value) ? portableResolve(value) : null;
 }
 
 export function requireAbsoluteRoot(value: string): string {


### PR DESCRIPTION
Two commits, one theme: **project identity / path membership must be decided with the repo's cross-platform path tools, never native `node:path`**, whose semantics follow the host OS.

## 1. Project-root canonicalization (fixes the failing Windows CI)

The Windows matrix ([run 29355039645](https://github.com/vincent-kk/ogham/actions/runs/29355039645)) failed on `@ogham/cross-platform` `hostPaths.test.ts` (4) and `@ogham/filid` `serverLifecycle.test.ts` (1) while every POSIX runner passed.

**Root cause** — canonicalization used native `path.resolve`, which follows the host OS. On Windows `resolve("/proj/lifecycle")` → `C:\proj\lifecycle`; on POSIX it is a near no-op. So hostPaths assertions mismatched POSIX literals, and filid's boot-sweep hashed the *resolved* root while writers hashed the *raw* cwd → the sweep looked in a different cache dir and never pruned expired sessions (`expected true to be false`).

**Fix** — route through the existing `paths/compat/portableResolve`, which picks the win32/posix API from the path *flavor*, so a path resolves deterministically regardless of the OS the server runs on.
- `hostPaths/absoluteRoot.ts`: `resolve` → `portableResolve`. Propagates to every `projectRoot`/`tryProjectRoot` consumer (deilen, cennad, filid) — centralized in the cross-platform package.
- `filid/cwdHash.ts`: canonicalize via `portableResolve` before hashing, so writer and sweeper both reduce to `hash(portableResolve(cwd))`.

No test assertions needed editing — POSIX literals now hold on every runner.

## 2. maencof vault internal-dir containment (same class, found by audit)

An adversarial cross-platform audit surfaced the same bug shape in maencof's `vaultRedirector`: "is this path inside `.maencof` / `.maencof-meta`" used native `resolve`/`relative` + a case-sensitive `startsWith`/`===`. On Windows (case-insensitive FS) a mixed-case spelling (`.Maencof-Meta/notes.md`) points at the same dir yet missed the match, firing a spurious redirect hint — a classification that diverged Windows vs POSIX.

**Fix** — `isVaultInternalPath` / `isVaultDocDirectory` now use `portableResolve` / `portableRelative` and compare containment on absolute paths via `pathForCompare` (folds case for Windows-flavored paths, stays case-sensitive for POSIX — each FS's real rule). Now flavor-driven and pure, so verifiable on any runner with drive-letter inputs (tests added).

## Verification

- Local (macOS): `yarn typecheck` + `yarn build:all` + `yarn test:run` (467 files) + `yarn lint` (0 errors) all clean.
- Hook-bundle guards pass for both filid (`cwdHash` via setup hook) and maencof (`vaultRedirector` via pre-tool-use hook) — light compat helpers stay under the byte caps, no forbidden modules.
- Non-mixed-case, real Windows/POSIX paths resolve identically to before; only cross-flavor and mixed-case-on-Windows inputs change.
- Windows behavior verified authoritatively by this PR's Actions run.

## Notes

- Source-only (6 files). Plugin `bridge/` artifacts are regenerated by the release build, not committed here (CI rebuilds from source via `build:all`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)